### PR TITLE
Support for <%# comments %>

### DIFF
--- a/lib/processors/ejs.js
+++ b/lib/processors/ejs.js
@@ -29,14 +29,12 @@ module.exports = {
   preprocess: function(text) {
     markers = [];
     // Break text into lines and create final lines array
-    var commentBlock = /<%#.*?%>/gm
+    var commentBlock = /<%#.*?%>/gm // Remove comment blocks entirely
     var lines = text.replace(commentBlock, '').split(/\r?\n/);
     var finalLines = []
 
     for (var i = 0; i < lines.length; i++) {
       var line = lines[i];
-
-      // Remove comment blocks entirely
 
       // Create array of marker locations and for each marker to remove
       var locations = [];

--- a/lib/processors/ejs.js
+++ b/lib/processors/ejs.js
@@ -26,15 +26,17 @@ if (typeof Object.assign != 'function') {
 var markers = [];
 
 module.exports = {
-
   preprocess: function(text) {
     markers = [];
     // Break text into lines and create final lines array
-    var lines = text.split(/\r?\n/);
+    var commentBlock = /<%#.*?%>/gm
+    var lines = text.replace(commentBlock, '').split(/\r?\n/);
     var finalLines = []
 
     for (var i = 0; i < lines.length; i++) {
       var line = lines[i];
+
+      // Remove comment blocks entirely
 
       // Create array of marker locations and for each marker to remove
       var locations = [];
@@ -61,6 +63,7 @@ module.exports = {
           column += width;
         }
       });
+      
       // Locations neeed to be sorted by column
       locations.sort(function(left, right) {
         left.column <= right.column;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "eslint-plugin-ejs",
-  "version": "0.2.0",
+  "name": "@angelventura/eslint-plugin-ejs",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angelventura/eslint-plugin-ejs",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Parses out ejs declarations found in js files",
   "main": "lib/index.js",
   "directories": {

--- a/tests/lib/processors/ejs.js
+++ b/tests/lib/processors/ejs.js
@@ -12,6 +12,13 @@ describe('preprocess', function() {
     expect(processor.preprocess(input)).to.deep.equal(['var identifier = 4;']);
   });
 
+  it('removes <%# comments %>', function() {
+    var input = "Some lines of text\n# Not a comment block\n<%# I'm a comment %>\n<%= <%# I'm an embedded comment %>I'm not a comment%>\n<%# I'm another comment %>\nComments<%# like this%> should be removed";
+    var output = "Some lines of text\n# Not a comment block\n\nI'm not a comment\n\nComments should be removed";
+
+    expect(processor.preprocess(input)).to.deep.equal([output]);
+  });
+
   it('removes <% markers', function() {
     var input = 'var <% identifier = 4;';
     expect(processor.preprocess(input)).to.deep.equal(['var identifier = 4;']);


### PR DESCRIPTION
EJS supports comment blocks which should be completely removed from the
perspective of the derivative code (and should therefore be ignored by
any linter).

I added logic to strip out comments entirely before processing the
markers.  Test coverage is included.